### PR TITLE
Allow skipping push

### DIFF
--- a/commands/pick/git-pick.ts
+++ b/commands/pick/git-pick.ts
@@ -3,6 +3,7 @@ import { runAndCapture, runCommand } from 'lib/shell/shell.ts';
 import { colors } from 'cliffy/ansi';
 
 export interface GitPickSettings {
+	push: boolean;
 	fetch: boolean;
 	pr: boolean;
 
@@ -38,8 +39,10 @@ export async function runCherryPick(settings: GitPickSettings): Promise<void> {
 	const commitSHAsToPick = settings.commits.map((c) => c.sha);
 	await runCommand('git', 'cherry-pick', ...commitSHAsToPick);
 
-	console.log(colors.green(`▶️ Pushing to ${settings.pushRemote}/${settings.branchName}`));
-	await runCommand('git', 'push', '-u', settings.pushRemote, settings.branchName);
+	if (settings.push) {
+		console.log(colors.green(`▶️ Pushing to ${settings.pushRemote}/${settings.branchName}`));
+		await runCommand('git', 'push', '-u', settings.pushRemote, settings.branchName);
+	}
 
 	if (settings.pr) {
 		console.log(colors.green('▶️ Creating pull request'));

--- a/commands/pick/pick-command.ts
+++ b/commands/pick/pick-command.ts
@@ -17,6 +17,9 @@ export const pickCommand = new Command()
 	)
 	.option('--no-fetch', 'Don\'t run git fetch before creating the branch')
 	.option('--no-pr', 'Skip creating a pull request on Github')
+	.option('--no-push', 'Skip pushing to push remote (implies --no-pr)', {
+		action: (options) => options.pr = false,
+	})
 	.option('-b, --branch <branchName:string>', 'Name to use for the new branch')
 	.option('-c, --commits <commitSha...:string>', 'Commits to cherry-pick')
 	.option('--pull-remote <remote:string>', 'Remote to use for fetching', {


### PR DESCRIPTION
cliffy seems to not handle the combination of boolean flags with conflicts,
so manually setting pr to false when --no-push specified
