### PR TITLE
Fix rmdir error because of duplicate cleanup

### DIFF
--- a/commands/pick/steps/git-pick.ts
+++ b/commands/pick/steps/git-pick.ts
@@ -42,6 +42,7 @@ export async function runCherryPick(settings: GitPickSettings): Promise<void> {
 			tmpDir,
 			upstreamRef,
 		);
+		cleanupSteps.pop(); // Leave cleanup of directory to git now
 		cleanupSteps.push({
 			message: colors.green('▶️ Cleaning up temporary worktree'),
 			action: async () => await runCommand('git', 'worktree', 'remove', tmpDir),


### PR DESCRIPTION
rmdir: failed to remove '/tmp/tmp.FHfmq4ObDH': No such file or directory
