### PR TITLE
Test new body generation

### DIFF
--- a/commands/pick/steps/confirm-settings.ts
+++ b/commands/pick/steps/confirm-settings.ts
@@ -34,14 +34,15 @@ export async function confirmSettings(
 	const pushOptions = `${check(options.push)} ${forceString}push`;
 
 	const draftString = options.draftPR ? `${colors.underline.white('draft')} ` : '';
-	const prOptions = `${check(options.pr)} ${draftString}pull request`;
+	const prOptions = `${check(options.pr)} ${draftString}pull request: ${options.title}`;
 
 	const lines = [
 		`${i}About to cherry pick commits:`,
 		...commitLines,
 		`${i}Base branch: ${pullRemote}/${upstreamBranch}`,
 		`${i}Branch name: ${pushRemote}/${branchName}${branchExistsWarning}`,
-		`${i}${pushOptions}  |  ${prOptions}`,
+		`${i}${pushOptions}`,
+		`${i}${prOptions}`,
 	];
 
 	await Gum.style(lines, {

--- a/commands/pick/steps/git-pick.ts
+++ b/commands/pick/steps/git-pick.ts
@@ -63,7 +63,7 @@ export async function runCherryPick(settings: GitPickSettings): Promise<void> {
 			settings.forcePush && args.push('--force');
 			await runCommand('git', 'push', ...args, settings.branchName);
 		}
-		// test 1
+		// test 2
 
 		if (settings.pr) {
 			log.info(colors.green('▶️ Creating pull request'));

--- a/commands/pick/steps/git-pick.ts
+++ b/commands/pick/steps/git-pick.ts
@@ -17,6 +17,9 @@ export interface GitPickSettings {
 	upstreamBranch: string;
 
 	commits: Commit[];
+
+	title: string;
+	body: string;
 }
 
 export async function runCherryPick(settings: GitPickSettings): Promise<void> {
@@ -65,6 +68,8 @@ export async function runCherryPick(settings: GitPickSettings): Promise<void> {
 			log.info(colors.green('▶️ Creating pull request'));
 			// Check if a pr is already open, using: `gh api "/repos/{owner}/{repo}/pulls?state=all&head={owner}:install-deps-command-for-gum" -q ".[] | {url}"`
 			await GH.createPullRequest({
+				title: settings.title,
+				body: settings.body,
 				baseBranch: settings.upstreamBranch,
 				draftPR: settings.draftPR,
 			});

--- a/commands/pick/steps/git-pick.ts
+++ b/commands/pick/steps/git-pick.ts
@@ -63,6 +63,7 @@ export async function runCherryPick(settings: GitPickSettings): Promise<void> {
 			settings.forcePush && args.push('--force');
 			await runCommand('git', 'push', ...args, settings.branchName);
 		}
+		// test 1
 
 		if (settings.pr) {
 			log.info(colors.green('▶️ Creating pull request'));

--- a/e2e-test/tests/pick.spec.ts
+++ b/e2e-test/tests/pick.spec.ts
@@ -43,7 +43,8 @@ test('pr-cli pick', async ({ cli, _tmpdir }) => {
 		/commit 1/,
 		/Base branch: upstream\/trunk/,
 		/Branch name: origin\/commit-1-branch/,
-		/✔ push .* ✗ pull request/,
+		/✔ push/,
+		/✗ pull request/,
 		/Continue?/,
 	]);
 

--- a/lib/git/git.ts
+++ b/lib/git/git.ts
@@ -8,9 +8,11 @@ export interface Commit {
 export class Git {
 	public static verifyAndExpandCommitSHAs = verifyAndExpandCommitSHAs;
 	public static getCommits = getCommits;
+	public static getCommitBody = getCommitBody;
 	public static fetch = gitFetch;
 	public static listRemotes = listRemotes;
 	public static doesBranchExist = doesBranchExist;
+	public static isValidBranchName = isValidBranchName;
 }
 
 async function verifyAndExpandCommitSHAs(
@@ -25,8 +27,8 @@ async function verifyAndExpandCommitSHAs(
 				'--verify',
 				`${commitSHA}^{commit}`,
 			);
-		} catch {
-			throw new Error('Given commits are invalid');
+		} catch (e) {
+			throw new Error('Given commits are invalid', { cause: e });
 		}
 	}));
 }
@@ -40,11 +42,32 @@ async function getCommits(revisionRange: string): Promise<Commit[]> {
 			'--pretty=format:%h %s',
 			revisionRange,
 		);
+
+		if (!result) {
+			// When no commits found we get an empty string
+			return [];
+		}
+
 		return result
 			.split('\n')
 			.map(lineToCommit);
-	} catch {
-		throw new Error('Failed to retrieve recent commits');
+	} catch (e) {
+		throw new Error('Failed to retrieve recent commits', { cause: e });
+	}
+}
+
+async function getCommitBody(commitSha: string): Promise<string> {
+	try {
+		const result = await runAndCapture(
+			'git',
+			'show',
+			'--quiet',
+			'--pretty=format:%b',
+			commitSha,
+		);
+		return result.trimEnd();
+	} catch (e) {
+		throw new Error(`Failed to retrieve commit body for ${commitSha}`, { cause: e });
 	}
 }
 
@@ -75,6 +98,15 @@ async function listRemotes(): Promise<string[]> {
 async function doesBranchExist(branch: string): Promise<boolean> {
 	try {
 		await runVoid('git', 'rev-parse', '--verify', branch);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function isValidBranchName(branchName: string): Promise<boolean> {
+	try {
+		await runVoid('git', 'check-ref-format', '--branch', branchName);
 		return true;
 	} catch {
 		return false;

--- a/lib/github/gh.ts
+++ b/lib/github/gh.ts
@@ -6,6 +6,9 @@ export class GH {
 }
 
 async function createPullRequest(options: {
+	title: string;
+	body: string;
+
 	baseBranch?: string;
 	draftPR?: boolean;
 }) {
@@ -17,7 +20,10 @@ async function createPullRequest(options: {
 		'gh',
 		'pr',
 		'create',
-		'--fill',
+		'--title',
+		options.title,
+		'--body',
+		options.body,
 		'--assignee',
 		'@me',
 		...args,

--- a/lib/slug/slug.ts
+++ b/lib/slug/slug.ts
@@ -1,7 +1,7 @@
 import { slug } from '../../deps.ts';
 
-export function slugify(s: string): string {
-	return slug(s, {
+export function slugify(string: string): string {
+	return slug(string, {
 		locale: 'uk',
 		lower: true,
 		trim: true,
@@ -10,4 +10,8 @@ export function slugify(s: string): string {
 		remove: undefined,
 		replacement: '-',
 	});
+}
+
+export function unslugify(slug: string): string {
+	return slug.replaceAll('-', ' ');
 }

--- a/main.ts
+++ b/main.ts
@@ -43,9 +43,17 @@ if (import.meta.main) {
 			log.info('Command Aborted');
 		} else {
 			log.error(colors.bgRed.brightWhite.bold(` ❗ ${err.message ?? err} `));
-			log.debug(err);
+			logError(err);
 		}
 		Deno.exit(1);
+	}
+}
+
+function logError(err: Error) {
+	log.debug(err);
+	if (err.cause instanceof Error) {
+		log.debug('Caused by: ');
+		logError(err.cause);
 	}
 }
 


### PR DESCRIPTION
<details>
<summary>Generate pull request and body ourselves, instead of letting GitHub do it</summary>

For a single commit, the title and body are:
title: commit subject
body: commit subject\n\ncommit body

For multiple commits:
title: branch-name converted to human-readable (removed - and capitalized)
body:
every commit separated by horizontal lines
just the title prepended with `▹ ` for commits without a body
summary/detail block for commits with a body

Fixes #38
</details>

---
▹ A commit without a body

---
<details>
<summary>Another commit, this time with a body</summary>

There's text here!

> And a quote

<details>
<summary>it even has a nested summary block></summary>

Which contains even more text
</details>

# Heading

horizontal line:

---

thats about it
</details>