### PR TITLE
Use git cherry to only show relevant commits

### DIFF
--- a/commands/pick/pick-command.ts
+++ b/commands/pick/pick-command.ts
@@ -162,7 +162,7 @@ async function parseOrPromptForCommits(
 	}
 
 	log.debug('Ask user to pick from \'new\' commits (local not on remote)');
-	const newCommits = await Git.getCommits(`${upstreamRef}..`);
+	const newCommits = await Git.getCommitsToCherryPick(upstreamRef);
 	if (newCommits.length < 1) {
 		throw new Error('No commits to pick');
 	}


### PR DESCRIPTION
Use git cherry to only show relevant commits

Git cherry can check whether a commits contents already exist
on a target branch. Using this we can return only relevant commits,
without the user having to rebase first

Fixes #68