### PR TITLE
Update pr command to generate title and body the same way as pick

### DIFF
--- a/commands/pick/steps/git-pick.ts
+++ b/commands/pick/steps/git-pick.ts
@@ -2,7 +2,7 @@ import { colors, log } from '../../../deps.ts';
 import { runAndCapture, runCommand } from '../../../lib/shell/shell.ts';
 import { GH } from '../../../lib/github/gh.ts';
 import { Commit } from '../../../lib/git/commit.ts';
-import { isDebugModeEnabled } from '../../../lib/pr-cli/debug.ts';
+import { Git } from '../../../lib/git/git.ts';
 
 export type GitPickSettings = Readonly<{
 	push: boolean;
@@ -61,10 +61,11 @@ export async function runCherryPick(settings: GitPickSettings): Promise<void> {
 
 		if (settings.push) {
 			log.info(colors.green(`▶️ Pushing to ${settings.pushRemote}/${settings.branchName}`));
-			const args = ['-u', settings.pushRemote];
-			settings.forcePush && args.push('--force');
-			isDebugModeEnabled() || args.push('--quiet');
-			await runCommand('git', 'push', ...args, settings.branchName);
+			await Git.push({
+				remote: settings.pushRemote,
+				branch: settings.branchName,
+				force: settings.forcePush,
+			});
 		}
 
 		if (settings.createPR) {

--- a/commands/pull-request/pull-request-command.ts
+++ b/commands/pull-request/pull-request-command.ts
@@ -1,13 +1,73 @@
 import { colors, Command, log } from '../../deps.ts';
 import { GH } from '../../lib/github/gh.ts';
+import { Git } from '../../lib/git/git.ts';
+import { getPullRemote, getPushRemote } from '../../lib/pr-cli/remotes.ts';
+import { getDefaultBranch } from '../../lib/pr-cli/default-branch.ts';
+import {
+	generatePullRequestBody,
+	generatePullRequestTitle,
+} from '../../lib/pr-cli/pull-request.ts';
 
 export const pullRequestCommand = new Command()
 	.name('pull-request')
 	.alias('pr')
 	.description('Create a pull request for the current branch')
-	.arguments('[baseBranch:string]')
-	.action(async (_options, upstreamBranch) => {
-		await GH.createPullRequest({ baseBranch: upstreamBranch, autofill: true });
+	.group('Toggles')
+	.option('--no-fetch', 'Don\'t run git fetch before creating the branch')
+	.option('--force', 'Overwrite existing branch, and force push to it')
+	.option('--web', 'Open the web browser to create a pull request')
+	.group('Inputs')
+	.option('-b, --branch <branchName:string>', 'Name to use for the new branch')
+	.option('-B, --base <baseBranch:string>', 'The branch into which you want your code merged')
+	.option('-c, --commits <commitSha...:string>', 'Commits to cherry-pick')
+	.option('--pull-remote <remote:string>', 'Remote to use for fetching')
+	.option('--push-remote <remote:string>', 'Remote to push to')
+	.group('Pull request')
+	.option('--draft', 'Mark the created pull request as Draft')
+	.option('--title <title:string>', 'Title for the pull request')
+	.action(async (options) => {
+		options.pullRemote ??= await getPullRemote();
+		options.pushRemote ??= await getPushRemote();
+		options.base ??= await getDefaultBranch(options.pullRemote, options.pushRemote);
+
+		const branchName = await Git.getCurrentBranch();
+
+		if (options.fetch) {
+			log.debug('Running git fetch');
+			await Git.fetch(options.pullRemote);
+			log.debug('Completed git fetch');
+		} else {
+			log.info(colors.white('-️ Skipping fetch'));
+		}
+
+		const newCommits = await Git.getCommits(`${options.pullRemote}/${options.base}..`);
+
+		if (newCommits.length < 1) {
+			throw new Error('No new commit on this branch');
+		}
+		if (newCommits.length === 1) {
+			options.title ??= newCommits[0]!.message;
+		}
+
+		const title = options.title ?? generatePullRequestTitle(branchName);
+		log.debug(`Using pull request title: ${title}`);
+
+		const body = await generatePullRequestBody(newCommits);
+		log.debug(`Generated pull request body:\n${body}`);
+
+		await Git.push({
+			remote: options.pushRemote,
+			branch: branchName,
+			force: options.force ?? false,
+		});
+
+		await GH.createPullRequest({
+			title: title,
+			body: body,
+			baseBranch: options.base,
+			draftPR: options.draft ?? false,
+			web: options.web ?? false,
+		});
 
 		log.info(colors.bgGreen.brightWhite('✔ Done!'));
 	});

--- a/lib/github/gh.ts
+++ b/lib/github/gh.ts
@@ -9,6 +9,7 @@ export class GH {
 interface BasePROptions {
 	baseBranch?: string;
 	draftPR?: boolean;
+	web?: boolean;
 }
 
 interface ManualTitleAndBody {
@@ -26,6 +27,7 @@ async function createPullRequest(options: PullRequestOptions) {
 	const args: string[] = [];
 	options.baseBranch && args.push('--base', options.baseBranch);
 	options.draftPR && args.push('--draft');
+	options.web && args.push('--web');
 
 	if ('autofill' in options) {
 		args.push('--fill');


### PR DESCRIPTION
Update pr command to generate title and body the same way as pick

This brings the resulting PR on par with the pick command.
The user experience isn't at the same level yet, however:
- A git pull should (optionally) be done before pushing
- Support for editing pr title/body should be added

Fixes #85