### PR TITLE
Wait for GitHub to process `git push` before updating PR

### DIFF
--- a/lib/git/git.ts
+++ b/lib/git/git.ts
@@ -1,7 +1,7 @@
 import { log } from '../../deps.ts';
+import { isDebugModeEnabled } from '../pr-cli/debug.ts';
 import { runAndCapture, runQuietly } from '../shell/shell.ts';
 import { Commit, CommitWithBody } from './commit.ts';
-import { isDebugModeEnabled } from '../pr-cli/debug.ts';
 
 export class Git {
 	public static verifyAndExpandCommitSHAs = verifyAndExpandCommitSHAs;
@@ -15,6 +15,7 @@ export class Git {
 	public static isValidBranchName = isValidBranchName;
 	public static getCurrentBranch = getCurrentBranch;
 	public static getHeadOfRemote = getHeadOfRemote;
+	public static getHEADCommitSha = getHEADCommitSha;
 }
 
 async function verifyAndExpandCommitSHAs(
@@ -143,11 +144,21 @@ async function listRemotes(): Promise<string[]> {
 
 async function doesBranchExist(branch: string): Promise<boolean> {
 	try {
-		await runQuietly('git', 'rev-parse', '--verify', branch);
+		await revParse(branch, { verify: true });
 		return true;
 	} catch {
 		return false;
 	}
+}
+
+async function getHEADCommitSha() {
+	return await revParse('HEAD');
+}
+
+async function revParse(revision: string, options?: { verify?: boolean }) {
+	const args: string[] = [];
+	options?.verify && args.push('--verify');
+	return await runQuietly('git', 'rev-parse', ...args, revision);
 }
 
 async function isValidBranchName(branchName: string): Promise<boolean> {

--- a/lib/github/gh.ts
+++ b/lib/github/gh.ts
@@ -6,6 +6,7 @@ export const GH = {
 	editPullRequest,
 	doesBranchHavePullRequest,
 	listPullRequests,
+	getPullRequestInfoForCurrentBranch,
 };
 
 interface BasePROptions {
@@ -34,6 +35,21 @@ type PullRequestOptions =
 	& CreatePROptions
 	& (ManualTitleAndBody | AutomaticTitleAndBody);
 type EditPullRequestOptions = BasePROptions & ManualTitleAndBody;
+
+async function getPullRequestInfoForCurrentBranch() {
+	const json = await runAndCapture(
+		'gh',
+		'pr',
+		'view',
+		'--json',
+		'headRefOid,number',
+	);
+	const pr = JSON.parse(json);
+	return {
+		headRefOid: pr.headRefOid as string,
+		number: pr.number as number,
+	};
+}
 
 async function createPullRequest(options: PullRequestOptions) {
 	const args: string[] = [];

--- a/lib/sleep.ts
+++ b/lib/sleep.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
#### Wait for GitHub to process `git push` before updating PR

Updating the pull request (with `gh pr edit`) right after a git push
was causing the `synchronize` webhook to be fired twice. This results
in GitHub Actions being started twice as well.

This commit adds a check before editing a pull request that compares
the current HEAD commit with the head id on GitHub. If these don't
match, it means that GitHub has not yet processed the git push.
We check this up to five times, waiting one second between checks.

Fixes #189