### PR TITLE
Add markers around PR body and only replace generated part when updating

### DIFF
--- a/commands/pick/pick-command.ts
+++ b/commands/pick/pick-command.ts
@@ -127,12 +127,6 @@ export const pickCommand = new Command()
 			log.info(overwriteLocalBranch ? 'Overwriting local branch!' : 'Not overwriting local branch');
 		}
 
-		// This promise is only set if it should be checked, undefined otherwise (await undefined = undefined)
-		const updatePR = await doesBranchHavePullRequest ?? false;
-		if (updatePR) {
-			log.info('PR exists, updating it!');
-		}
-
 		let forcePush = options.force === true;
 		if (!forcePush && options.push && remoteBranchExists) {
 			forcePush = await Gum.confirm({
@@ -144,6 +138,12 @@ export const pickCommand = new Command()
 
 		const body = await generatePullRequestBody(pickedCommits);
 		log.debug(`Generated pull request body:\n${body}`);
+
+		// This promise is only set if it should be checked, undefined otherwise (await undefined = undefined)
+		const updatePR = await doesBranchHavePullRequest ?? false;
+		if (updatePR) {
+			log.info('PR exists, updating it!');
+		}
 
 		const settings = await confirmSettings(
 			{

--- a/commands/update-pull-request/update-pull-request-command.ts
+++ b/commands/update-pull-request/update-pull-request-command.ts
@@ -11,7 +11,7 @@ export const updatePullRequestCommand = new Command()
 	.action(async () => {
 		await checkDependencies();
 
-		const prs = await GH.listPullRequests();
+		const prs = await GH.listPullRequests({ author: '@me' });
 		if (prs.length < 1) {
 			throw new Error('No pull requests to update');
 		}

--- a/lib/pr-cli/pr-body.test.ts
+++ b/lib/pr-cli/pr-body.test.ts
@@ -1,11 +1,17 @@
-import { formatCommits } from './pr-body.ts';
+import {
+	endMarker,
+	formatPullRequestBody,
+	replacementExplanation,
+	replacePRCLIPartOfBody,
+	startMarker,
+} from './pr-body.ts';
 import { assertEquals } from 'https://deno.land/std@0.207.0/assert/mod.ts';
 import { CommitWithBody } from '../git/commit.ts';
 
 Deno.test('No commits', () => {
 	assertFormattedEquals(
 		[],
-		'',
+		`${startMarker}\n${replacementExplanation}\n\n${endMarker}`,
 	);
 });
 
@@ -16,7 +22,7 @@ Deno.test('One commit', () => {
 			body: 'Body\nOf\nCommit',
 			sha: 'sha',
 		}],
-		'#### Message\n\nBody\nOf\nCommit',
+		`${startMarker}\n${replacementExplanation}\n#### Message\n\nBody\nOf\nCommit\n${endMarker}`,
 	);
 });
 
@@ -27,7 +33,7 @@ Deno.test('Indent', () => {
 			body: 'Body\n - Of\n - Commit',
 			sha: 'sha',
 		}],
-		'#### Message\n\nBody\n - Of\n - Commit',
+		`${startMarker}\n${replacementExplanation}\n#### Message\n\nBody\n - Of\n - Commit\n${endMarker}`,
 	);
 });
 
@@ -42,10 +48,36 @@ Deno.test('Multiple commits', () => {
 			body: 'Commit2\nBody',
 			sha: 'sha2',
 		}],
-		'#### Message1\n\nCommit1\nBody\n\n<br>\n\n#### Message2\n\nCommit2\nBody',
+		`${startMarker}\n${replacementExplanation}\n#### Message1\n\nCommit1\nBody\n\n<br>\n\n#### Message2\n\nCommit2\nBody\n${endMarker}`,
+	);
+});
+
+Deno.test('Replacing pr-cli part of body', () => {
+	assertEquals(replacePRCLIPartOfBody('no markers', 'new'), 'new');
+	assertEquals(
+		replacePRCLIPartOfBody(
+			`before start ${startMarker} after end`,
+			'new',
+		),
+		'before start new',
+	);
+	assertEquals(
+		replacePRCLIPartOfBody(
+			`before start ${startMarker} between markers ${endMarker} after end`,
+			'new',
+		),
+		'before start new after end',
+	);
+
+	assertEquals(
+		replacePRCLIPartOfBody(
+			`before start\n${startMarker}\nbetween markers\n${endMarker}\nafter end`,
+			'new',
+		),
+		'before start\nnew\nafter end',
 	);
 });
 
 function assertFormattedEquals(commits: CommitWithBody[], expected: string) {
-	assertEquals(formatCommits(commits), expected);
+	assertEquals(formatPullRequestBody(commits), expected);
 }


### PR DESCRIPTION
I've added this bit to the PR body manually on GitHub, it should now be kept when updating the PR.

<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### Move PR update check after force push and body

<br>

#### Add markers around PR body and only replace generated part when updating

Fixes #185
<!-- pr-cli body end -->