### PR TITLE
Limit branch name to 244 characters, to prevent errors

### DIFF
--- a/lib/gum/confirm/confirm.ts
+++ b/lib/gum/confirm/confirm.ts
@@ -9,10 +9,10 @@ export async function _gum_confirm(options?: {
 	timeout?: number;
 }): Promise<boolean> {
 	const args = [];
-	options?.prompt && args.push(options.prompt);
-	options?.affirmativeLabel && args.push(`--affirmative=${options.affirmativeLabel}`);
-	options?.negativeLabel && args.push(`--negative=${options.negativeLabel}`);
-	options?.timeout && args.push(`--timeout=${options.timeout}`);
+	options?.prompt !== undefined && args.push(options.prompt);
+	options?.affirmativeLabel !== undefined && args.push(`--affirmative=${options.affirmativeLabel}`);
+	options?.negativeLabel !== undefined && args.push(`--negative=${options.negativeLabel}`);
+	options?.timeout !== undefined && args.push(`--timeout=${options.timeout}`);
 
 	if (options?.startOnAffirmative) {
 		args.push(`--default=${options?.startOnAffirmative}`);

--- a/lib/gum/input/input.ts
+++ b/lib/gum/input/input.ts
@@ -6,6 +6,7 @@ export async function _gum_input(options?: {
 	placeholder?: string;
 	prompt?: string;
 	defaultValue?: string;
+	characterLimit?: number;
 }): Promise<string> {
 	if (options?.prompt && options?.defaultValue) {
 		options.prompt += colors.dim.white('(Ctrl+U to clear) ');
@@ -14,12 +15,15 @@ export async function _gum_input(options?: {
 	const args = [];
 	options?.placeholder && args.push(`--placeholder=${options.placeholder}`);
 	options?.prompt && args.push(`--prompt=${options.prompt}`);
+	options?.characterLimit && args.push(`--char-limit=${options.characterLimit}`);
 	options?.defaultValue && args.push(`--value=${options.defaultValue}`);
+
+	const width = Math.min(80, options?.characterLimit ?? Number.POSITIVE_INFINITY);
 
 	return await runAndCapture(
 		'gum',
 		'input',
-		'--width=80',
+		`--width=${width}`,
 		`--prompt.foreground=${ColorScheme.primary}`,
 		...args,
 	);

--- a/lib/pr-cli/branch.ts
+++ b/lib/pr-cli/branch.ts
@@ -1,5 +1,6 @@
 import { slugify, unslugify } from '../slug/slug.ts';
 import { Git } from '../git/git.ts';
+import { Config } from './config.ts';
 
 export function convertBranchNameToTitle(branchName: string): string {
 	let title = unslugify(branchName);
@@ -9,12 +10,17 @@ export function convertBranchNameToTitle(branchName: string): string {
 }
 
 export function convertToValidBranchName(message: string): string {
-	return slugify(message);
+	return slugify(message).slice(0, Config.maxBranchNameLength);
 }
 
 export async function assertValidBranchName(branchName: string) {
 	if (!await Git.isValidBranchName(branchName)) {
-		throw new Error(`Branch name "${branchName}" is invalid`);
+		throw new InvalidBranchNameError(`Branch name "${branchName}" is invalid`);
+	}
+	if (branchName.length > Config.maxBranchNameLength) {
+		throw new InvalidBranchNameError(
+			`Branch name "${branchName}" exceeds maximum length of ${Config.maxBranchNameLength}`,
+		);
 	}
 }
 
@@ -28,3 +34,5 @@ export async function getDefaultBranch(...remotesToTry: string[]): Promise<strin
 
 	throw new Error('Unable to determine default branch, please specify it yourself');
 }
+
+class InvalidBranchNameError extends Error {}

--- a/lib/pr-cli/config.ts
+++ b/lib/pr-cli/config.ts
@@ -1,0 +1,3 @@
+export const Config = {
+	maxBranchNameLength: 244, // The max GitHub allows, ext4 starts complaining above 250
+} as const;


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### Limit branch name to 244 characters, to prevent errors

- Branch names over 250 characters cause issues on ext4 filesystems
- Branch names over 244 characters are rejected by GitHub

Fixes #253
<!-- pr-cli body end -->