### PR TITLE
When editing title, skip strategy selection and go straight to input

### DIFF
--- a/commands/pick/pick-command.ts
+++ b/commands/pick/pick-command.ts
@@ -15,7 +15,7 @@ import { checkDependencies } from './steps/check-dependencies.ts';
 import { ColorScheme } from '../../lib/colors.ts';
 import { formatObjectForLog } from '../../lib/pr-cli/debug.ts';
 import { chooseMultipleFormatted } from '../../lib/pr-cli/choose.ts';
-import { assertValidTitle, writeTitle } from '../../lib/pr-cli/pr-title.ts';
+import { assertValidTitle, selectTitle } from '../../lib/pr-cli/pr-title.ts';
 import { generatePullRequestBody, replacePRCLIPartOfBody } from '../../lib/pr-cli/pr-body.ts';
 import { Command } from '@cliffy/command';
 import { colors } from '@cliffy/ansi/colors';
@@ -102,7 +102,7 @@ export const pickCommand = new Command()
 			throw new Error('No commits chosen');
 		}
 
-		const title = options.title ?? await writeTitle({
+		const title = options.title ?? await selectTitle({
 			branchName: options.branch, // This option is only shown if branch was pre-provided
 			commits: pickedCommits,
 		});

--- a/commands/pick/steps/confirm-settings.ts
+++ b/commands/pick/steps/confirm-settings.ts
@@ -5,7 +5,7 @@ import { getKeySequence } from '../../../lib/keypress.ts';
 import { Git } from '../../../lib/git/git.ts';
 import type { GumStyleOptions } from '../../../lib/gum/style/style.ts';
 import { chooseOne } from '../../../lib/pr-cli/choose.ts';
-import { writeTitle } from '../../../lib/pr-cli/pr-title.ts';
+import { editTitle, selectTitle } from '../../../lib/pr-cli/pr-title.ts';
 import { writePullRequestBody } from '../../../lib/pr-cli/pr-body.ts';
 import { CommandExecutionError } from '../../../lib/shell/command-execution-error.ts';
 import { colors } from '@cliffy/ansi/colors';
@@ -263,7 +263,12 @@ async function listenForKeySequence(
 			// Title
 			't': async (settings: GitPickSettings) => ({
 				...settings,
-				title: await writeTitle({
+				title: await editTitle(settings.title),
+			}),
+			// Title
+			'ctrl+t': async (settings: GitPickSettings) => ({
+				...settings,
+				title: await selectTitle({
 					commits: settings.commits,
 					branchName: settings.branchName,
 					currentTitle: settings.title,

--- a/commands/pull-request/pull-request-command.ts
+++ b/commands/pull-request/pull-request-command.ts
@@ -3,7 +3,7 @@ import * as log from '@std/log';
 import { Git } from '../../lib/git/git.ts';
 import { getPullRemote, getPushRemote } from '../../lib/pr-cli/remotes.ts';
 import { checkDependencies } from '../pick/steps/check-dependencies.ts';
-import { writeTitle } from '../../lib/pr-cli/pr-title.ts';
+import { selectTitle } from '../../lib/pr-cli/pr-title.ts';
 import { generatePullRequestBody } from '../../lib/pr-cli/pr-body.ts';
 import { getDefaultBranch } from '../../lib/pr-cli/branch.ts';
 import { Command } from '@cliffy/command';
@@ -50,7 +50,7 @@ export const pullRequestCommand = new Command()
 			throw new Error('No new commit on this branch');
 		}
 
-		options.title ??= await writeTitle({ commits: newCommits, branchName });
+		options.title ??= await selectTitle({ commits: newCommits, branchName });
 		if (!options.title) {
 			throw new Error('Pull request title is empty');
 		}

--- a/lib/pr-cli/pr-title.ts
+++ b/lib/pr-cli/pr-title.ts
@@ -15,7 +15,7 @@ type TitleStrategy = {
 	execute: () => Promise<string> | string;
 };
 
-export async function writeTitle(context: TitleContext): Promise<string> {
+export async function selectTitle(context: TitleContext): Promise<string> {
 	const manualStrategy = getManualStrategy(context.currentTitle);
 	const options: readonly TitleStrategy[] = [
 		context.commits ? getCommitStrategy(context.commits) : null,
@@ -32,7 +32,11 @@ export async function writeTitle(context: TitleContext): Promise<string> {
 		},
 	);
 
-	return chosenOption.execute();
+	return await chosenOption.execute();
+}
+
+export async function editTitle(currentTitle: string): Promise<string> {
+	return await getManualStrategy(currentTitle).execute();
 }
 
 function getCommitStrategy(commits: Commit[]): TitleStrategy {


### PR DESCRIPTION
<!-- pr-cli body start -->
<!-- Anything between the start and end tags will be replaced when updating a PR -->
#### When editing title, skip strategy selection and go straight to input

In the settings phase, you've already selected a title strategy.
Changing the strategy at that point is unlikely.

The old behaviour can still be triggered by using ctrl+t

Fixes #212
<!-- pr-cli body end -->